### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/personal_finance/static/js/realtime/websocket-client.js
+++ b/personal_finance/static/js/realtime/websocket-client.js
@@ -367,10 +367,21 @@ class WebSocketClient {
         this.assetSubscriptions.forEach(symbol => {
             const li = document.createElement('li');
             li.className = 'mb-1';
-            li.innerHTML = `
-                <span class="badge badge-primary me-2">${symbol}</span>
-                <button class="btn btn-xs btn-outline-danger" onclick="wsClient.unsubscribeFromAsset('${symbol}')">×</button>
-            `;
+
+            // Badge span
+            const badge = document.createElement('span');
+            badge.className = 'badge badge-primary me-2';
+            badge.textContent = symbol;
+
+            // Unsubscribe button
+            const button = document.createElement('button');
+            button.className = 'btn btn-xs btn-outline-danger';
+            button.textContent = '×';
+            button.type = 'button';
+            button.addEventListener('click', () => this.unsubscribeFromAsset(symbol));
+
+            li.appendChild(badge);
+            li.appendChild(button);
             container.appendChild(li);
         });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/MauGx3/personal-finance/security/code-scanning/18](https://github.com/MauGx3/personal-finance/security/code-scanning/18)

To fix this problem, any user-controlled input (specifically, the `symbol`) must be **properly escaped before being placed in an HTML context** and when injected into inline JavaScript handlers (`onclick`). The best practice is to avoid `innerHTML` and inline JavaScript where possible. However, if you must generate HTML using string interpolation, ensure **HTML escaping** for visible content, and when placing user data inside script/attribute contexts, adopt **appropriate attribute/context escaping**.

Specifically:  
- Instead of using `li.innerHTML = ...`, create the DOM substructure manually using DOM APIs (e.g., `createElement`, `appendChild`, `textContent`).  
- Set the symbol via `textContent` or by `.appendChild(document.createTextNode(symbol))` rather than interpolating into HTML.
- For the button, use an event listener rather than an `onclick` attribute, or carefully escape the symbol.
  - Since the button calls `wsClient.unsubscribeFromAsset(symbol)`, use a `data-` attribute on the button to store the symbol, and wire up the event with `addEventListener`.

**Files/lines to change:**  
- File: `personal_finance/static/js/realtime/websocket-client.js`
- Lines: 367–373 (within `updateAssetSubscriptions()`).

**Required changes:**  
- Replace the build of `li.innerHTML` with safe DOM manipulation.  
- Attach event listeners to the button dynamically using JS, passing the correct symbol.

No new libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
