### PR TITLE
Potential fix for code scanning alert no. 9248: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,8 @@ jobs:
           pytest -q || [ $? -eq 5 ]
 
   security-audit:
+    permissions:
+      contents: read
     name: Security audit (pip-audit)
     runs-on: ubuntu-latest
     needs: test


### PR DESCRIPTION
Potential fix for [https://github.com/MauGx3/personal-finance/security/code-scanning/9248](https://github.com/MauGx3/personal-finance/security/code-scanning/9248)

To fix the problem, explicitly set the minimal permissions required for the `security-audit` job, using the `permissions` key. Since this job only needs to read from the repository (for actions/checkout to work), the minimal required is `contents: read`. To achieve this, add the following block directly under the `security-audit:` definition and above `name: Security audit (pip-audit)` (i.e., at line 54), with proper indentation. No changes are needed elsewhere. No dependencies are needed to implement the fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
