### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MauGx3/personal-finance/security/code-scanning/1](https://github.com/MauGx3/personal-finance/security/code-scanning/1)

The best fix is to explicitly add a `permissions` block at the top level of the workflow (after `name:` and before `on:`), setting the minimum required for all jobs in the workflow—`contents: read` in this case. This ensures that the `GITHUB_TOKEN` cannot make write operations (such as pushing code, editing issues, etc.) unless further permissions are selectively granted to specific jobs later. To implement this change, edit `.github/workflows/ci.yml` and insert:

```yaml
permissions:
  contents: read
```

immediately after the first line (`name: CI`). No new imports, methods, or other code changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
