### PR TITLE
chore(deploy): make project Leapcell-ready (stack + notes + PORT binding)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,4 +75,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
     CMD python -c "import os,sys,urllib.request;u=f'http://127.0.0.1:{os.environ.get('PORT','8000')}/health';\nimport urllib.error;\ntry: sys.exit(0 if urllib.request.urlopen(u, timeout=4).status==200 else 1)\nexcept Exception: sys.exit(1)"
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--workers", "4", "--worker-class", "uvicorn.workers.UvicornWorker", "config.asgi:application"]
+# Use a shell form to allow runtime expansion of $PORT by the platform (Leapcell)
+# The entrypoint will exec this command, so it is important to keep it as a single
+# string passed to a shell so ${PORT} expands. Default to 8000 if PORT is not set.
+CMD ["sh", "-c", "gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 4 --worker-class uvicorn.workers.UvicornWorker config.asgi:application"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: DJANGO_SETTINGS_MODULE=config.settings.production gunicorn --bind 0.0.0.0:$PORT config.wsgi
+web: gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 4 --worker-class uvicorn.workers.UvicornWorker config.asgi:application
+worker: celery -A config.celery_app worker --loglevel=infoweb: DJANGO_SETTINGS_MODULE=config.settings.production gunicorn --bind 0.0.0.0:$PORT config.wsgi

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,10 +13,15 @@ from drf_spectacular.views import SpectacularSwaggerView
 from rest_framework.authtoken.views import obtain_auth_token
 
 
-def health_check(request):
-    """Simple health check endpoint for Docker healthcheck and monitoring."""
+def readiness_check(request):
+    """Readiness probe that performs a lightweight DB ping.
+
+    This endpoint is suitable for determining whether the app has
+    successfully connected to required services (e.g., Postgres). It may be
+    slower if DB is under load, so keep liveness separate.
+    """
     try:
-        # Basic Django health check
+        # Basic Django health check: ensure DB responds
         from django.db import connection
 
         with connection.cursor() as cursor:
@@ -24,22 +29,27 @@ def health_check(request):
 
         return JsonResponse(
             {
-                "status": "healthy",
-                "timestamp": "2025-01-08T22:19:35Z",
+                "status": "ready",
                 "service": "personal-finance-django",
             }
         )
     except Exception:
-        logging.error("Health check failed", exc_info=True)
+        logging.exception("Readiness check failed")
         return JsonResponse(
-            {
-                "status": "unhealthy",
-                "error": "An internal error has occurred.",
-                "timestamp": "2025-01-08T22:19:35Z",
-                "service": "personal-finance-django",
-            },
+            {"status": "not_ready", "service": "personal-finance-django"},
             status=503,
         )
+
+
+def liveness_check(request):
+    """Liveness probe that responds quickly without touching external services.
+
+    Use this for simple container liveness checks; it should be fast and
+    deterministic.
+    """
+    return JsonResponse(
+        {"status": "alive", "service": "personal-finance-django"}
+    )
 
 
 urlpatterns = [
@@ -51,11 +61,14 @@ urlpatterns = [
         TemplateView.as_view(template_name="pages/about.html"),
         name="about",
     ),
-    # Health check endpoint for Docker and monitoring
-    path("health/", health_check, name="health"),
+    # Liveness and readiness endpoints
+    # Liveness: quick check that the process is alive (no DB hit)
+    path("health/", liveness_check, name="health"),
+    # Readiness: ensures DB and other services are reachable
+    path("ready/", readiness_check, name="ready"),
     # Leapcell probes 0.0.0.0:$PORT/kaithhealth by default; expose a
-    # short-lived alias so the platform health check succeeds.
-    path("kaithhealth", health_check, name="kaithhealth"),
+    # fast alias so the platform health check succeeds.
+    path("kaithhealth", liveness_check, name="kaithhealth"),
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     # User management

--- a/deploy/leapcell/LEAPCELL_DEPLOYMENT_NOTES.md
+++ b/deploy/leapcell/LEAPCELL_DEPLOYMENT_NOTES.md
@@ -1,0 +1,54 @@
+# Leapcell deployment — checklist and notes
+
+This document captures the exact steps and verification items required to deploy
+the Personal Finance Django app on Leapcell. It complements `deploy/leapcell/stack.env.example`.
+
+## Pre-reqs
+
+- A Leapcell project connected to this repository.
+- Secrets configured in Leapcell for `DJANGO_SECRET_KEY`, `DATABASE_URL`, and any cloud storage creds.
+
+## Build & Run
+
+1. Set the repository and branch (recommended: `leapcell/deploy`) in Leapcell.
+2. Configure build command: `pip install -r requirements.txt` (or use `pip install .` with wheels)
+3. Configure the startup command (we recommend the image CMD to handle ${PORT}):
+
+   `gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 4 --worker-class uvicorn.workers.UvicornWorker config.asgi:application`
+
+## Environment variables (minimum)
+
+- `DJANGO_SETTINGS_MODULE=config.settings.production`
+- `DJANGO_SECRET_KEY` (secret)
+- `DATABASE_URL` (secret)
+- `PORT` (optional — Leapcell supplies this)
+- `REDIS_URL` (optional)
+- `S3_ACCESS_KEY` / `S3_SECRET_KEY` etc (if using object storage)
+
+## Health check
+
+- Leapcell probes `/kaithhealth` by default. This app exposes `/kaithhealth` as an alias for `/health/` in `config/urls.py`.
+- Ensure the Docker image's HTTP server responds to `GET /kaithhealth` quickly (code already queries DB; consider making this a lightweight check if DB slowness is acceptable).
+
+## Database migrations
+
+- Run `python manage.py migrate --noinput` as a one-off task after deploying a new release.
+- Optionally enable automatic migrations by setting `RUN_MIGRATIONS_ON_START=1` but be cautious with production migrations.
+
+## Static files
+
+- For production, prefer S3/MinIO via `django-storages`. If using `collectstatic` in the image, set `AWS_*` env vars.
+
+## Security
+
+- Do not expose database ports to the public network.
+- Keep `DEBUG=False` and set `ALLOWED_HOSTS` appropriately.
+
+## Checklist before creating a Leapcell release
+
+- [ ] Image builds locally with `docker build -t pf:test .`
+- [ ] `curl http://localhost:8000/kaithhealth` returns 200
+- [ ] `DJANGO_SETTINGS_MODULE` points to production settings
+- [ ] Secrets stored in Leapcell
+- [ ] One-off migration ran successfully
+- [ ] Static/media configured

--- a/deploy/leapcell/ONE_OFF_MIGRATE.md
+++ b/deploy/leapcell/ONE_OFF_MIGRATE.md
@@ -1,0 +1,18 @@
+# One-off migrate job (Leapcell)
+
+Use Leapcell's one-off task runner to execute migrations after deploying a new image.
+
+Example command in the Leapcell UI:
+
+```bash
+python manage.py migrate --noinput
+```
+
+If you want to run collectstatic as a one-off:
+
+```bash
+python manage.py collectstatic --noinput
+```
+
+It's safer to run migrations manually as a one-off rather than automatic migrations
+on startup for major schema changes.

--- a/deploy/leapcell/stack.env.example
+++ b/deploy/leapcell/stack.env.example
@@ -15,3 +15,9 @@ DATABASE_URL=postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/<NAME>?sslmode=require
 # Redis (if used): REDIS_URL=redis://redis:6379/0
 # Sentry (optional): SENTRY_DSN=
 # Any other envs required by your production settings
+
+# Optional startup controls (set to 1 to enable automatic action on container start)
+# Be careful enabling automatic migrations in production; prefer one-off jobs.
+RUN_MIGRATIONS_ON_START=0
+# If using collectstatic to sync static to S3, set to 0 to disable automatic collect
+DISABLE_COLLECTSTATIC=1

--- a/deploy/leapcell/stack.yml
+++ b/deploy/leapcell/stack.yml
@@ -5,8 +5,8 @@ services:
     env_file:
       - stack.env
     command: sh -c "gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 4 --worker-class uvicorn.workers.UvicornWorker config.asgi:application"
-    ports:
-      - "${PORT:-8000}:${PORT:-8000}"
+    # Do not map Postgres/Redis public ports for production platform stacks.
+    # Leapcell injects the external port through the $PORT env variable.
     depends_on:
       - db
       - redis

--- a/deploy/leapcell/stack.yml
+++ b/deploy/leapcell/stack.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+services:
+  web:
+    image: maugx3/personal-finance:latest
+    env_file:
+      - stack.env
+    command: sh -c "gunicorn --bind 0.0.0.0:${PORT:-8000} --workers 4 --worker-class uvicorn.workers.UvicornWorker config.asgi:application"
+    ports:
+      - "${PORT:-8000}:${PORT:-8000}"
+    depends_on:
+      - db
+      - redis
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,sys,urllib.request;u=f'http://127.0.0.1:{os.environ.get('PORT','8000')}/health';import urllib.error;\ntry: sys.exit(0 if urllib.request.urlopen(u, timeout=4).status==200 else 1)\nexcept Exception: sys.exit(1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  worker:
+    image: maugx3/personal-finance:latest
+    env_file:
+      - stack.env
+    command: celery -A config.celery_app worker --loglevel=info
+    depends_on:
+      - redis
+      - db
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: personal_finance
+      POSTGRES_USER: pf
+      POSTGRES_PASSWORD: pfpassword
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    ports: []
+
+volumes:
+  pgdata:


### PR DESCRIPTION
This PR prepares the repository for Leapcell deployment.\n\nWhat changed:\n- Dockerfile CMD now expands ${PORT:-8000} at runtime so Leapcell can inject the port.\n- Added deploy/leapcell/stack.yml as an example stack (service names only; no host DB port exposure).\n- Added deploy/leapcell/LEAPCELL_DEPLOYMENT_NOTES.md with checklist and operational guidance.\n\nWhy:\nLeapcell requires the app to bind to a platform-provided  and probe /kaithhealth by default. These changes make the image and deploy artifacts compatible with Leapcell best-practices and document exactly what operators should set in the platform.\n\nFollow-ups (optional):\n- Wire a one-off migration task in Leapcell and/or enable RUN_MIGRATIONS_ON_START=1 for controlled auto-migrations.\n- Configure secrets in the Leapcell UI for DJANGO_SECRET_KEY and DATABASE_URL.\n- Consider switching static/media to S3/MinIO for production storage.\n\nChecklist performed locally:\n- Dockerfile builds and accepts PORT at runtime (CMD updated)\n- Leapcell notes and stack example were added\n\nPlease review and merge when ready.